### PR TITLE
Fix board rendering issue where Unicode block characters (▁ ▔) showed…

### DIFF
--- a/src/main/java/org/tictactoe/Board.java
+++ b/src/main/java/org/tictactoe/Board.java
@@ -32,7 +32,7 @@ public class Board {
         }
     }
     public void print(){
-        System.out.println("▁▁▁▁▁▁▁");
+        System.out.println("───────");
         for(int i = 0; i < 3; i++){
             for(int j = 0; j < 3; j++){
                 System.out.print("|");
@@ -42,6 +42,6 @@ public class Board {
                 }
             }
         }
-        System.out.println("▔▔▔▔▔▔▔");
+        System.out.println("───────");
     }
 }


### PR DESCRIPTION
… as '?' due to console encoding/font limitations